### PR TITLE
replace browserify with monobrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.bcache.json
 .DS_Store
 dist
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ CSS atoms for X-Team branded sites
 ## Setup
 ```
 npm install
-npm run setup
 ```
 
 ## Development
+
+Start browserify hot-reload mode, and open a browser window:
 ```
 npm start
 ```
+
+## Building files
+
+- `npm run build`: build the js bundle as normal
+- `npm run build -- -w`: build the js bundle in watch-mode

--- a/monobrow/config.js
+++ b/monobrow/config.js
@@ -1,0 +1,15 @@
+const css = require('browserify-css')
+
+module.exports = {
+    entry: 'src/index.js',
+    output: {
+        dir: 'dist',
+        bundle: 'bundle.js'
+    },
+
+    packs: [
+        function (b) {
+            b.transform(css)
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "CSS atoms for X-Team branded sites",
   "main": "index.js",
   "scripts": {
-    "setup": "mkdir dist && touch dist/bundle.js",
-    "build": "browserify -t browserify-css -o dist/bundle.js src/index.js",
-    "start": "watchify -v -p browserify-hmr -t browserify-css -o dist/bundle.js src/index.js & node server.js & wait",
+    "build": "monobrow",
+    "start": "monobrow --hot & node server.js & wait",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -25,12 +24,10 @@
   },
   "homepage": "https://github.com/x-team/atoms#readme",
   "devDependencies": {
-    "browserify": "^13.1.0",
     "browserify-css": "^0.10.0",
-    "browserify-hmr": "^0.3.1",
     "ecstatic": "^2.1.0",
-    "open": "0.0.5",
-    "watchify": "^3.7.0"
+    "monobrow": "^2.6.3",
+    "open": "0.0.5"
   },
   "dependencies": {
     "classnames": "^2.2.5",


### PR DESCRIPTION
`monobrow` is basically `browserify` + `watchify` + `browserify-hmr` and a couple of other things wrapped together. So we can clean up package.json and the build scripts.

It also creates the `dist` directory automatically, so we don't need to run `npm run setup` anymore.